### PR TITLE
fixup!: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ services:
       - 9700:9700/udp
     volumes:
       - ./steamcmd:/steamcmd
-      - ./game:/theforest
+      - ./game:/sonsoftheforest
       - ./winedata:/winedata
 ```
 


### PR DESCRIPTION
The `docker-compose.yml` example on the `README.md` included the wrong directory - now it's fixed.