### PR TITLE
fix/failed_install_app_2465200_missing_file_permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ services:
     environment:
       ALWAYS_UPDATE_ON_START: 1
       SKIP_NETWORK_ACCESSIBILITY_TEST: false
+      HOME: /home/steam
     ports:
       - 8766:8766/udp
       - 27016:27016/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       ALWAYS_UPDATE_ON_START: 1
       SKIP_NETWORK_ACCESSIBILITY_TEST: false
+      HOME: /home/steam
     ports:
       - 8766:8766/udp
       - 27016:27016/udp


### PR DESCRIPTION
Add HOME environment variable to README.md and docker-compose.yml to fix `Unable to run container (ERROR! Failed to install app '2465200' (Missing file permissions))`